### PR TITLE
feat: add backup script for fluentd logs

### DIFF
--- a/bin/container-backup
+++ b/bin/container-backup
@@ -1,0 +1,33 @@
+#!/bin/ash
+# Nyx Calder - Backup script for fluentd logs and position files
+# Created on: 2026-04-07
+set -e
+
+BACKUP_DIR="/mnt/volumes/backup"
+LOG_DIR="/var/log/fluentd"
+POS_DIR="/var/lib/fluentd/pos"
+TIMESTAMP=$(date +%Y%m%d%H%M%S)
+BACKUP_FILE="$BACKUP_DIR/fluentd-backup-$TIMESTAMP.tar.gz"
+
+echo "Starting fluentd backup..."
+
+# Ensure backup directory exists
+mkdir -p "$BACKUP_DIR"
+
+# Check if there is anything to backup
+if [ ! -d "$LOG_DIR" ] && [ ! -d "$POS_DIR" ]; then
+    echo "Nothing to backup ($LOG_DIR and $POS_DIR do not exist)."
+    exit 0
+fi
+
+# Create tarball of logs and position files
+# Capture /var/log/fluentd and /var/lib/fluentd/pos if they exist
+echo "Archiving to $BACKUP_FILE..."
+tar -czf "$BACKUP_FILE" "$LOG_DIR" "$POS_DIR" 2>/dev/null || true
+
+# Keep only last 10 backups
+echo "Cleaning up old backups..."
+# shellcheck disable=SC2012
+ls -1tr "$BACKUP_DIR"/fluentd-backup-*.tar.gz 2>/dev/null | head -n -10 | xargs rm -f 2>/dev/null || true
+
+echo "Backup complete: $BACKUP_FILE"

--- a/container.build
+++ b/container.build
@@ -49,9 +49,10 @@ RUN /usr/sbin/addgroup $USER adm
 # ╭―
 # │ BACKUP
 # ╰――――――――――――――――――――
-# No backup needed and even disable the automated hourly backup
-RUN rm -f /etc/periodic/hourly/container-backup
-# COPY backup /etc/container/backup
+# Backup enabled for fluent logs and position files
+COPY bin/container-backup /etc/container/backup
+RUN /bin/mkdir -p /etc/periodic/hourly
+RUN /bin/ln -fsv /etc/container/backup /etc/periodic/hourly/container-backup
 
 # ╭―
 # │ ENTRYPOINT
@@ -63,6 +64,8 @@ COPY entrypoint /etc/container/entrypoint
 # ╰――――――――――――――――――――╯
 
 RUN /bin/mkdir -p /mnt/volumes/logs/pods /mnt/volumes/logs/nodes
+RUN /bin/mkdir -p /var/log/fluentd /var/lib/fluentd/pos
+RUN /usr/sbin/chown -R $USER:$USER /var/log/fluentd /var/lib/fluentd/pos
 
 RUN /bin/ln -fsv /mnt/volumes/configmaps/fluentd.conf /etc/container/fluentd.conf
 COPY --from=SOURCE /fluentd/pkg/fluentd-*.gem /opt/fluentd/


### PR DESCRIPTION
## Summary
Added an hourly backup script to archive fluentd logs (`/var/log/fluentd`) and position files (`/var/lib/fluentd/pos`).

### Changes:
- **Backup Script**: Created `bin/container-backup` to archive logs and position files, and keep the last 10 backups.
- **Dockerfile**:
  - Re-enabled the automated hourly backup using the new script.
  - Ensured `/var/log/fluentd` and `/var/lib/fluentd/pos` exist and are owned by the `fluentd` user.
- **Local Testing**: Verified `bin/container-backup` with `shellcheck` and `container.build` with `hadolint`.

Risk: Low